### PR TITLE
LIST 7.11にてrequest.get()の戻り値をrで取得するように修正

### DIFF
--- a/source/textbook/7_scraping.rst
+++ b/source/textbook/7_scraping.rst
@@ -244,7 +244,7 @@ Requests の主な使い方
    :caption: 認証付きURLにアクセスする
 
    >>> import requests
-   >>> requests.get('https://api.github.com/user', auth=('user', 'pass'))
+   >>> r = requests.get('https://api.github.com/user', auth=('user', 'pass'))
    >>> r.status_code
    200
 


### PR DESCRIPTION
チケットへのリンク

- なし

このレビューで確認して欲しい点

- [ ] LIST 7.11の3行目にてr.status_codeと記述されていますが、一つ上の行のrequests.get()で戻り値のrを取得していないためエラーとなります。