### PR TITLE
コマンド実行例では python ではなく python3 を指定する

### DIFF
--- a/source/textbook/2_intro.rst
+++ b/source/textbook/2_intro.rst
@@ -260,7 +260,7 @@ Python ファイルを作成して実行する場合は、 ``print`` 関数が�
 .. code-block:: bash
     :caption: fizzbuzz.pyの実行
 
-    $ python fizzbuzz.py
+    $ python3 fizzbuzz.py
     4
 
 ファイルが存在するフォルダと、ターミナル/コマンドプロンプトの現在位置があっているか注意してください。
@@ -271,7 +271,7 @@ fizzbuzz.pyが見つからない場合は場合は、以下のようなエラー
 .. code-block:: guess
     :caption: fizzbuzz.pyの実行
 
-    $ python fizzbuzz.py
+    $ python3 fizzbuzz.py
     can't open file 'fizzbuzz.py': [Errno 2] No such file or directory
 
 for文
@@ -298,7 +298,7 @@ for文
 .. code-block:: bash
     :caption: fizzbuzz.pyの実行(2)
 
-    $ python fizzbuzz.py
+    $ python3 fizzbuzz.py
     1
     2
     3

--- a/source/textbook/6_pyvenv.rst
+++ b/source/textbook/6_pyvenv.rst
@@ -81,7 +81,7 @@ venv環境を作成します。
 .. code-block:: sh
    :caption: venv環境の作成(macOS、Windows、Linux)
 
-    $ python -m venv env
+    $ python3 -m venv env
     $ ls
     env/
 

--- a/source/textbook/7_scraping.rst
+++ b/source/textbook/7_scraping.rst
@@ -22,7 +22,7 @@ venv環境をactivateコマンドで有効にし、スクレイピングに使�
 
    $ mkdir scraping
    $ cd scraping
-   $ python -m venv env
+   $ python3 -m venv env
    $ source env/bin/activate
    (env) $ pip install requests
    (env) $ pip install beautifulsoup4
@@ -86,7 +86,7 @@ Pythonの標準ライブラリ `html.parser <https://docs.python.jp/3/library/ht
 .. code-block:: bash
    :caption: スクレイピングを実行
 
-   (env) $ python simple.py
+   (env) $ python3 simple.py
    株式会社フンザ http://hunza.jp/
    MonotaRO https://www.monotaro.com/
    Gandi.net https://www.gandi.net/


### PR DESCRIPTION
`$ python` だと python2 が起動するおそれがあるので、
`$ python3` のように python3 の利用を明示するのが良いと思います。

----

チケットへのリンク

- なし

このレビューで確認して欲しい点

- [ ] 提案した修正内容で問題ないかどうか
