### PR TITLE
code-blockでのハイライト指定を Pythonコード(`python`)ではなく、Pythonコンソール(`pycon`)に修正

### DIFF
--- a/source/textbook/1_install.rst
+++ b/source/textbook/1_install.rst
@@ -140,7 +140,7 @@ Pythonのソースコードをビルドし、インストールします（:numr
 
    /opt/python3.5.3 ディレクトリ以下にインストールするには、次のように指定します
 
-    .. code-block:: python
+    .. code-block:: none
         :caption: prefixオプション付きconfigure
 
         LDFLAGS="-L/usr/lib/x86_64-linux-gnu" ./configure --prefix=/opt/python3.5.3 --with-ensurepip

--- a/source/textbook/2_intro.rst
+++ b/source/textbook/2_intro.rst
@@ -53,7 +53,7 @@ Pythonを電卓にする
 
 .. _python-calc:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 四則演算と代入
 
     >>> 2 + 2
@@ -88,7 +88,7 @@ Pythonを電卓にする
 
 .. _string-type:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列型
 
     >>> 'Hello,world'
@@ -116,7 +116,7 @@ Pythonを電卓にする
 
 .. _list:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: リスト
 
     >>> ['Hello', 3]
@@ -133,7 +133,7 @@ Pythonを電卓にする
 
 .. _python-comment:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: コメントの書き方
 
     >>> # ここはコメント文
@@ -154,7 +154,7 @@ Pythonでは関数は、 ``def`` を使って以下のように書きます。
 
 .. _function-def:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 関数定義と呼び出し
 
     >>> def add(a, b):
@@ -189,7 +189,7 @@ Pythonには標準でいくつか関数が提供されています。これを�
 たとえば、指定された小数点を丸めた値を作成する ``round()`` 関数は、 このように使います。
 
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 組み込み関数round
 
     >>> round(10.4)

--- a/source/textbook/3_types.rst
+++ b/source/textbook/3_types.rst
@@ -25,7 +25,7 @@ Pythonのデータ型（基本編）
 
 .. _type-int:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 整数型
 
     >>> 2 + 2
@@ -45,7 +45,7 @@ Pythonのデータ型（基本編）
 
 .. _divide-int:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 整数型同士の商
 
     >>> 10 / 3
@@ -60,7 +60,7 @@ Pythonのデータ型（基本編）
 
 .. _double-slash:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: //での割り算
 
     >>> 10 // 3
@@ -79,7 +79,7 @@ Pythonのデータ型（基本編）
 
 .. _type-float:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 浮動小数点型
 
     >>> 5.0
@@ -103,7 +103,7 @@ Pythonのデータ型（基本編）
 
 .. _type-str:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列型
 
     >>> 'Hello,world'
@@ -120,7 +120,7 @@ Pythonのデータ型（基本編）
 
 .. _escape-string:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列中のエスケープ
 
     >>> print('I\'m Hiroki')
@@ -133,7 +133,7 @@ Pythonのデータ型（基本編）
 
 .. _single-quote:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: シングルクォートを含む文字列
 
     >>> print("I'm Hiroki")
@@ -148,7 +148,7 @@ Pythonのデータ型（基本編）
 
 .. _triple-quote:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 三重クォート
 
     >>> """ foo
@@ -168,7 +168,7 @@ Pythonのデータ型（基本編）
 
 .. _join-string:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列の結合
 
     >>> 'Mt.' + 'Fuji'
@@ -176,7 +176,7 @@ Pythonのデータ型（基本編）
 
 .. _multi-string:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列の繰り返し
 
     >>> 'spam' * 5
@@ -189,7 +189,7 @@ Pythonのデータ型（基本編）
 
 .. _string-index:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列から1文字取り出し
 
     >>> 'python'[1]
@@ -216,7 +216,7 @@ Pythonのスライスを使えば、 :numref:`slice-string` のように、2、3
 
 .. _slice-string:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列のスライス
 
     >>> 'python'[2:5]
@@ -232,7 +232,7 @@ Pythonのスライスを使えば、 :numref:`slice-string` のように、2、3
 
 .. _slice-stirng2:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 先頭末尾からのスライス
 
     >>> 'python'[:3]
@@ -248,7 +248,7 @@ Pythonのスライスを使えば、 :numref:`slice-string` のように、2、3
 
 .. _guide-len:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列長の取得
 
     >>> len('python')
@@ -261,7 +261,7 @@ Pythonのスライスを使えば、 :numref:`slice-string` のように、2、3
 
 .. _guide-in:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列中にある文字列が存在するかのチェック
 
     >>> 't' in 'python'
@@ -282,7 +282,7 @@ Pythonのスライスを使えば、 :numref:`slice-string` のように、2、3
 
 .. _guide-split:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列の分割
 
     >>> 'pain-au-chocolat'.split('-')
@@ -297,7 +297,7 @@ Pythonのスライスを使えば、 :numref:`slice-string` のように、2、3
 
 .. _guide-join:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 文字列の結合
 
     >>> '-'.join(['pain', 'de', 'campagne'])

--- a/source/textbook/4_collections.rst
+++ b/source/textbook/4_collections.rst
@@ -19,7 +19,7 @@ Pythonのデータ型のうち、複数のデータ型をひとまとめにし�
 
 .. _define-list:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: リストの定義
 
     >>> ['spam', 'egg', 0.5]
@@ -29,7 +29,7 @@ Pythonのデータ型のうち、複数のデータ型をひとまとめにし�
 
 .. _use-list:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: リストの基本的な使い方
 
     >>> ['spam', 'ham'] + ['egg']              # リストの結合
@@ -52,7 +52,7 @@ for文
 
 .. _for-list:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: for文とリスト
 
     >>> for animal in ['cat', 'dog', 'snake']:
@@ -74,7 +74,7 @@ for文
 
 .. _list-append:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: リストへの要素追加
 
     >>> animals = ['cat', 'dog', 'snake']
@@ -98,7 +98,7 @@ for文
 
 .. _general-for:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 一般的なfor文
 
     >>> ret = []
@@ -112,7 +112,7 @@ for文
 
 .. _list-comprehension:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: リスト内包表記
 
     >>> [len(animal) for animal in animals]
@@ -143,7 +143,7 @@ for文
 
 .. _multi-substitute:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: シーケンス型から複数変数への代入
 
     >>> dog, cat = ['dog', 'cat']
@@ -157,7 +157,7 @@ for文
 .. たとえば文字列を ``.split()`` メソッドで分割し、それぞれの変数へ代入すると便利です。
    HTTPのAuthorizationヘッダーをauth_type、auth_stringに分割する処理は以下のように書けます。
 
-   .. code-block:: python
+   .. code-block:: pycon
        :caption: splitメソッドと各要素個別の代入
 
        >>> authorization_header = 'Bearer ABCDEF'
@@ -175,7 +175,7 @@ for文
 
 .. _define-tuple:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: タプルの定義
 
     >>> ('spam', 'ham', 4)
@@ -185,7 +185,7 @@ for文
 
 .. _use-tuple:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: タプルの基本的な使い方
 
     >>> ('spam', 'ham') + ('egg',)             # タプルの結合
@@ -206,7 +206,7 @@ for文
 
 .. _single-tuple:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 1要素のタプル
 
     >>> ('spam',)
@@ -218,7 +218,7 @@ for文
 
 .. _omit-parenthesis-tuple:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 括弧を省略したタプル
 
     >>> 'dog', 'cat'
@@ -239,7 +239,7 @@ for文
 
 .. _return-tuple:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: タプルを返す関数
 
     >>> def head_splitter(seq):
@@ -255,7 +255,7 @@ for文
 
 .. _many-return-value:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 要素数の多いタプルを返す関数
 
     >>> def bad_implementation():
@@ -278,7 +278,7 @@ for文
 
 .. _guide-dict:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 辞書
 
     >>> user_info = {'user_name': 'taro', 'last_name': 'Yamada'}
@@ -289,7 +289,7 @@ for文
 
 .. _get-dict-value:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 辞書からの値の取り出し
 
     >>> user_info['user_name']
@@ -299,7 +299,7 @@ for文
 
 .. _set-dict-value:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 辞書への値の設定
 
     >>> user_info['first_name'] = 'Taro'
@@ -313,7 +313,7 @@ in
 
 .. _dict-in:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 辞書のin
 
     >>> 'user_name' in user_info
@@ -328,7 +328,7 @@ in
 
 .. _dict-keyerror:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 存在しないキーの参照
 
     >>> user_info['bio']
@@ -340,7 +340,7 @@ in
 
 .. _get-from-dict:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 存在しないキーへのget
 
     >>> user_info.get('user_name')
@@ -358,7 +358,7 @@ in
 
 .. _get-with-default:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: デフォルト値付きのget
 
     >>> user_info.get('bio', '')
@@ -370,7 +370,7 @@ for文
 
 .. _dict-for:
 
-.. code-block:: python
+.. code-block:: pycon
    :caption: 辞書を使用したfor文
 
    >>> user_info = {'user_name': 'taro', 'last_name': 'Yamada'}
@@ -400,7 +400,7 @@ for文
 
 .. _get-all-items:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 辞書内のすべてのキーと値を取得
 
     >>> d = {'foo': 'spam', 'bar': 'ham'}
@@ -413,7 +413,7 @@ for文
 
 .. _for-with-dict-items:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: for文で辞書のキーと値を使う
 
     >>> d = {'foo': 'spam', 'bar': 'ham'}
@@ -444,7 +444,7 @@ for文
 
 .. _define-set:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 集合の定義
 
     >>> {'spam', 'ham'}
@@ -460,7 +460,7 @@ for文
 
 .. _set-add-method:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 集合への要素の追加
 
     >>> unique_users = {'dog', 'cat'}
@@ -472,7 +472,7 @@ for文
 
 .. _len-with-set:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 集合によるユニーク数管理
 
     >>> len(unique_users)
@@ -498,7 +498,7 @@ for文
 
 .. _product-of-sets:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 2集合の積
 
     >>> allowed_permissions = {'edit', 'view'}
@@ -515,7 +515,7 @@ for文
 
 .. _sum-of-sets:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 2つの集合の和
 
     >>> editor = {'edit', 'comment'}

--- a/source/textbook/5_module.rst
+++ b/source/textbook/5_module.rst
@@ -34,7 +34,7 @@ Pythonでファイルを開くには ``open()`` 関数を使います。
 
 .. _file-open:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: ファイルを開く
 
     >>> f = open('todo.txt', encoding='utf-8')
@@ -53,7 +53,7 @@ Pythonでファイルを開くには ``open()`` 関数を使います。
 
 .. _read-file:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: ファイル内容の読み込み
 
     >>> todo_str = f.read()
@@ -69,7 +69,7 @@ Pythonでファイルを開くには ``open()`` 関数を使います。
 
 ファイルを閉じるには、ファイルオブジェクトの ``.close()`` メソッドを呼び出します。
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: ファイルを閉じる
 
     >>> f.close()
@@ -81,7 +81,7 @@ Pythonでファイルを開くには ``open()`` 関数を使います。
 
 .. _with-statement:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: ファイルオープンとwith文
 
     >>> with open('todo.txt', encoding='utf-8') as f:
@@ -99,7 +99,7 @@ Pythonでファイルを開くには ``open()`` 関数を使います。
 
 .. _write-mode:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 書き込みモードでファイルを開く
 
     >>> f = open('memo.txt', 'w', encoding='utf-8')
@@ -111,7 +111,7 @@ Pythonでファイルを開くには ``open()`` 関数を使います。
 
 .. _write-string:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: ファイル内容の書き込み
 
     >>> f.write('Hello')
@@ -138,7 +138,7 @@ Pythonでファイルを開くには ``open()`` 関数を使います。
 
 .. _append-mode:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 追記モードでファイルを開く
 
     >>> f = open('memo.txt', 'a', encoding='utf-8')
@@ -186,7 +186,7 @@ Pythonインタープリタを起動して、 ``calc.py`` をインポートし�
 
 .. _import-calc:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: calcのインポート
 
     >>> import calc
@@ -199,7 +199,7 @@ Pythonファイルをインポートすることでモジュール（module）�
 
 .. _call-calc-add:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 別モジュールの関数を利用
 
     >>> calc.add(1, 2)
@@ -214,7 +214,7 @@ Pythonファイルをインポートすることでモジュール（module）�
 
 .. _import-function:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 関数のインポート
 
     >>> from calc import add
@@ -232,7 +232,7 @@ Pythonファイルをインポートすることでモジュール（module）�
 
 .. _import-as:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: インポート対象に別名をつける
 
     >>> import calc as c
@@ -247,7 +247,7 @@ Pythonファイルをインポートすることでモジュール（module）�
 
 .. _import-functions:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 複数の対象をインポート
 
     >>> from calc import add, sub
@@ -261,7 +261,7 @@ Pythonファイルをインポートすることでモジュール（module）�
 
 .. _import-functions2:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 括弧を使った複数のインポート
 
     >>> from calc import (
@@ -288,7 +288,7 @@ Python自体も標準でモジュールを提供しています。これら標�
 
 .. _re-module:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: reモジュールの利用
 
     >>> import re
@@ -301,7 +301,7 @@ Python自体も標準でモジュールを提供しています。これら標�
 
 .. _match-object:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 正規表現にマッチした文字列の取得
 
     >>> m.group()
@@ -312,7 +312,7 @@ Python自体も標準でモジュールを提供しています。これら標�
 
 .. _match-group:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: グループを指定して文字列の取得
 
     >>> m = re.search('py(thon)', 'python')
@@ -327,7 +327,7 @@ Python自体も標準でモジュールを提供しています。これら標�
 
 .. _not-match:
 
-.. code-block:: python
+.. code-block:: pycon
     :caption: 正規表現にマッチしない場合
 
     >>> re.search('py', 'ruby')


### PR DESCRIPTION
このレビューで確認して欲しい点

- [ ] 修正が妥当かどうか