### PR TITLE
Change from apt-get to apt

### DIFF
--- a/source/textbook/1_install.rst
+++ b/source/textbook/1_install.rst
@@ -100,8 +100,8 @@ Ubuntu 17.04 にPython 3.6をインストールするには、apt-getコマン�
 .. code-block:: sh
    :caption: Python 3.6のインストール
 
-   $ sudo apt-get update
-   $ sudo apt-get -y install python3.6 python3.6-dev python3.6-venv
+   $ sudo apt update
+   $ sudo apt -y install python3.6 python3.6-dev python3.6-venv
 
 インストールが完了したらPythonのバージョンが3.6.1になっていることを確認します（:numref:`check-version`）。
 


### PR DESCRIPTION
参考URLにあるように、現在は `apt` コマンドが推奨されているため変更しました。

このレビューで確認して欲しい点

- [ ] `apt-get` コマンドを `apt` コマンドに置き換えられている

【参考】[6.2. aptitude、apt-get、apt コマンド](https://debian-handbook.info/browse/ja-JP/stable/sect.apt-get.html)