### PR TITLE
集合の「長さ」ではなく「要素数」とする

### DIFF
--- a/source/textbook/4_collections.rst
+++ b/source/textbook/4_collections.rst
@@ -480,7 +480,7 @@ for文
     >>> unique_users
     {'dog', 'cat', 'snake'}
 
-集合の長さも ``len()`` 関数で取得できます（:numref:`len-with-set`）。
+集合の要素数も ``len()`` 関数で取得できます（:numref:`len-with-set`）。
 
 .. _len-with-set:
 
@@ -496,7 +496,7 @@ for文
     3
 
 :numref:`len-with-set` で要素が2つの ``unique_users`` という集合を定義し、後に要素を追加しています。
-ここで ``unique_users`` の長さは3です。
+ここで ``unique_users`` の要素数は3です。
 :numref:`len-with-set` では、集合内にすでに存在する ``'snake'`` という要素を ``.add()`` で3 回追加していますが、 ``len()`` 関数の結果は変わりません。
 
 このように、集合では一意な値が適切に管理されていることがわかります。
@@ -523,7 +523,7 @@ for文
 
 集合の和も取得できます。
 両方の集合を合わせた集合を取得できます。
-2つの集合に対してオア（``¦``）演算子を使います（:numref:`sum-of-sets`）。
+2つの集合に対してOR（``¦``）演算子を使います（:numref:`sum-of-sets`）。
 
 .. _sum-of-sets:
 


### PR DESCRIPTION
4.5. 集合」のlen() 関数の記述においてリストやタプルと同様に「長さ」と表記しているが、
集合の場合は「要素数」の方が適切である。

issueへのリンク
- https://github.com/pyconjp/pycamp.pycon.jp/issues/109

このレビューで確認して欲しい点

- [x] 集合の長さではなく要素数と記述できているか