### PR TITLE
使用するエディターをAtomに統一

### DIFF
--- a/source/textbook/1_install.rst
+++ b/source/textbook/1_install.rst
@@ -16,7 +16,6 @@ Pythonをはじめましょう！
 
 .. index:: Editor
     single: Editor; Atom
-    single: Editor; PyCharm
 
 エディタの準備
 ==============
@@ -24,10 +23,8 @@ Pythonをはじめましょう！
 普段使用しているエディタがある人は、そのエディタを使用して構いません。
 Python の文法に対応しているエディタを使用することをおすすめします。
 
-普段使っているエディタがない人は、以下のいずれかをインストールしてください。
-
-- `Atom <https://atom.io/>`_: さまざまなプログラミング言語に対応したエディタ
-- `PyCharm <https://www.jetbrains.com/pycharm/>`_: Pythonに特化したIDE(統合開発環境)
+普段使っているエディタがない人は、 `Atom <https://atom.io/>`_ をインストールしてください。
+Atomはさまざまなプログラミング言語に対応したエディタで、拡張機能も豊富です。
 
 .. index:: Terminal
 


### PR DESCRIPTION
## このレビューで確認して欲しい点

- [ ] エディタがAtomに統一されている


## 補足説明

### Atomに統一している理由:
- 現在普及しているエディターの中で、インストールしてすぐにプログラムを書き始められるため
- エスクテンションが豊富
- オープンソースかつ無料で、さまざまなプログラミング言語に対応しているのでpycamp参加後も扱いやすい
- 講師が既に説明に慣れている

###  PyCharmが削除されている理由:
- AtomかPyCharmの **いずれか** だと、「せっかくだからPyCharmを」と導入し、参加者がうまく使えないケースがある
- 高機能だがAtomより重い
- いくつか設定が必要なことがあるので、普段使っていないTAがサポートできない可能性が十分にある

### VSCodeにしていない理由:
- Atomはインストールすればすぐに始められるが、VSCodeはエクステンションのインストールを求められるため
- 以下のように都度インストールを求められ、TAの説明コストが増える
  - Pythonのエクステンションのインストール
  - Linter(pylint)のインストール
  - (仮想環境が有効なshellから起動される場合) 仮想環境上にLinterが入っていないので、再度Linterのインストールが求められる

### 他のエディタでない理由:
- 講師側のスイッチコストが発生する
- SublimeText3: 評価版は無償だが継続利用するには有料のため
