### PR TITLE
fix requets url

### DIFF
--- a/source/textbook/7_scraping.rst
+++ b/source/textbook/7_scraping.rst
@@ -44,7 +44,7 @@ venv環境を ``activate`` コマンドで有効にし、Web APIとスクレイ�
 
 Requests
 --------
-:URL: http://docs.python-requests.org/
+:URL: http://python-requests.org/
 
 Requests について簡単に紹介します。
 Requests はウェブサイトにアクセスしてHTMLなどのデータを取得するためのライブラリです。
@@ -371,7 +371,7 @@ Requests の主な使い方
 ここでは Requests の主な使い方の例をいくつか載せます。
 詳細については以下の公式ドキュメントを参照してください。
 
-:公式ドキュメント: `Requests: HTTP for Humans <http://docs.python-requests.org/en/master/>`_
+:公式ドキュメント: `Requests: HTTP for Humans <http://python-requests.org/>`_
 
 以下は認証つきのURLにアクセスして、結果を取得する例です。
 


### PR DESCRIPTION
このレビューで確認して欲しい点

- [ ] RequestsのURLが http://docs.python-requests.org/ から http://python-requests.org/ に変わっていること
- [ ] http://python-requests.org/ のアクセスでrequestsのドキュメントが表示されること


経緯

* もとの http://docs.python-requests.org/ にアクセスすると https://2.python-requests.org にリダイレクトされますが、そこがhttpsで正しく通信できてないみたい
* PyPI の https://pypi.org/project/requests/ からのリンク先は http://python-requests.org/ で、リダイレクト先は https://requests.kennethreitz.org/en/master/ 。これは正しく表示される。
* テキストのリンク先を PyPIと同じ http://python-requests.org/ に変更するのがよさそう

出典: https://pyconjp.slack.com/archives/C0RE71RHD/p1572274591219200