### PR TITLE
Python3.y のような表記を Python 3.y に統一

### DIFF
--- a/source/textbook/1_install.md
+++ b/source/textbook/1_install.md
@@ -133,14 +133,14 @@ Python 3.10.8
 
 これ以降の本テキストでは上記手順でインストールしたPython 3.8以降を使用することを前提に記載しています。
 
-Python 2.7等のPython2系やAnacondaでインストールしたPython、または [Jupyter](https://jupyter.org/) や [Google Colaboratory](https://colab.research.google.com/?hl=ja) では実習ができません。
+Python 2.7等のPython 2系やAnacondaでインストールしたPython、または [Jupyter](https://jupyter.org/) や [Google Colaboratory](https://colab.research.google.com/?hl=ja) では実習ができません。
 
 Pythonを起動した時に表示される文字をチェックして、下記が問題ないか確認してください。
 
 - Pythonのバージョン(3.8以上であること)
 - Anacondaという文字が表示されないこと
 
-インストールされていない場合は前述の手順でPython3.10.8のインストールを行ってください。
+インストールされていない場合は前述の手順でPython 3.10.8のインストールを行ってください。
 
 ## まとめ
 

--- a/source/textbook/6_venv.md
+++ b/source/textbook/6_venv.md
@@ -63,7 +63,7 @@ $ pip install requests
 次に、独立したPython環境を構築する **venv** モジュールについて説明します。
 
 ```{admonition} コラム: Windows環境でpip実行時にエラーになる場合
-PATH環境変数を確認し、Python3 をインストールしているPATHが設定されているかどうか確認してみてください。
+PATH環境変数を確認し、Python 3 をインストールしているPATHが設定されているかどうか確認してみてください。
 ```
 
 ```{index} venv single: venv; Virtual Environments


### PR DESCRIPTION
チケットへのリンク

- ありません

このレビューで確認して欲しい点

- [x] Python3 や Python3.y といった表記を Python 3 や Python 3.y に統一する方針に問題がないこと