### PR TITLE
Python 3.7 以降の辞書の挿入順保持を反映 (#195)

### DIFF
--- a/source/textbook/4_collections.md
+++ b/source/textbook/4_collections.md
@@ -295,7 +295,7 @@ True
 
 辞書もリスト、タプルと同じコレクションです。
 
-辞書はリストとは違い、各要素に順番を持ちません。代わりにキー（key）と、対応する値（value）を持ちます。
+辞書の各要素はキー（key）と、対応する値（value）を持ち、Python 3.7 以降では要素の挿入順が保持されます。
 
 辞書を定義するには波括弧（`{}`）で各要素を囲み、コロン（`:`）でキーと値を書きます（{numref}`guide-dict`）。
 値と次のキーの間はカンマ（`,`）で区切ります。
@@ -307,7 +307,7 @@ True
 
 >>> user_info = {'user_name': 'taro', 'last_name': 'Yamada'}
 >>> user_info
-{'last_name': 'Yamada', 'user_name': 'taro'}
+{'user_name': 'taro', 'last_name': 'Yamada'}
 ```
 
 {numref}`guide-dict` の `user_info` から `'user_name'` の値を取り出す処理は、 {numref}`get-dict-value` になります。
@@ -330,7 +330,7 @@ True
 
 >>> user_info['first_name'] = 'Taro'
 >>> user_info
-{'first_name': 'Taro', 'last_name': 'Yamada', 'user_name': 'taro'}
+{'user_name': 'taro', 'last_name': 'Yamada', 'first_name': 'Taro'}
 ```
 
 ```{index} in single: Collection; in


### PR DESCRIPTION
チケットへのリンク

- #195 

このレビューで確認して欲しい点

- [x] 辞書の挿入順保持についての説明の方針。このテキストの範囲でより詳細に説明するべきか、かんたんな説明に留めるべきかどうか
- [x] (念のための確認) pythontutor.com が Python 3.6 までしか対応していないので、Python 3.7 以降で保証されている辞書の挿入順保持と厳密には整合性が取れない点について。実装上は CPython 3.6 から挿入順を保持しているため大きな問題はないかと思います。
