### PR TITLE
貢献者一覧に元原稿の提供者を追加

### DIFF
--- a/source/organize/3_contributers.md
+++ b/source/organize/3_contributers.md
@@ -3,6 +3,7 @@
 Python Boot Campのテキスト作成には以下の人たちが関わっています。
 
 - [takanory](https://github.com/takanory)
+- [hirokiky](https://github.com/hirokiky)
 - [Akira-Taniguchi](https://github.com/Akira-Taniguchi)
 - [ryu22e](https://github.com/ryu22e)
 - [terapyon](https://github.com/terapyon)


### PR DESCRIPTION
このPyCampテキストの元になった原稿を提供したので貢献者に追加してください。

このテキストの1章から5章までの内容は私の原稿が元になっています
（Pythonエンジニアファーストブックの原稿です）。
文章や画像も基本は変わっていないので追加されても良いかなと思っています。

contributorに追加を希望する場合は、以下にチェックを入れて`source/organize/3_contributers.rst`に自分の名前を入れた変更をこのPull Requestに加えること

- [x] contributorに追加を希望する
