### PR TITLE
インタープリタ起動コマンドの表記ゆれ修正

### DIFF
--- a/source/textbook/2_intro.md
+++ b/source/textbook/2_intro.md
@@ -284,7 +284,7 @@ Python ファイルを作成して実行する場合は、 `print` 関数が必�
 ```{code-block} bash
 :caption: "fizzbuzz.pyの実行"
 
-$ python3 fizzbuzz.py
+$ python fizzbuzz.py  # macOS、Linuxの場合はpython3（以下同様）
 4
 ```
 
@@ -299,7 +299,7 @@ fizzbuzz.pyが見つからない場合は場合は、以下のようなエラー
 ```{code-block} text
 :caption: "fizzbuzz.pyの実行"
 
-$ python3 fizzbuzz.py
+$ python fizzbuzz.py
 can't open file 'fizzbuzz.py': [Errno 2] No such file or directory
 ```
 
@@ -330,7 +330,7 @@ for num in range(1, 101):
 ```{code-block} bash
 :caption: "fizzbuzz.pyの実行(2)"
 
-$ python3 fizzbuzz.py
+$ python fizzbuzz.py
 1
 2
 3
@@ -460,7 +460,7 @@ for num in range(1, 101):
 ```{code-block} bash
 :caption: "完成したfizzbuzz.pyの実行"
 
-$ python3 fizzbuzz.py
+$ python fizzbuzz.py
 1
 2
 Fizz


### PR DESCRIPTION
チケットへのリンク

- [2.1 Pythonインタープリタ起動コマンドの表記揺れ #189](https://github.com/pyconjp/pycamp.pycon.jp/issues/189)

このレビューで確認して欲しい点

- 他の章も確認したうえでpythonに統一する判断をしたがそれでよいか
- macOS, Linuxはpython3 というコメントは初出1箇所（リスト2.10）のみにしたがそれでよいか

contributorに追加を希望する場合は、以下にチェックを入れて`source/organize/3_contributers.rst`に自分の名前を入れた変更をこのPull Requestに加えること

- [ ] contributorに追加を希望する
