### PR TITLE
ISSHA-3067 update sphinxext-opengraph and add settings for social cards

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 furo==2023.9.10
+matplotlib==3.8.0
 myst-parser==2.0.0
 Sphinx==7.2.6
 sphinx-copybutton==0.5.2
-sphinxext-opengraph==0.8.2
+sphinxext-opengraph==0.9.0

--- a/source/conf.py
+++ b/source/conf.py
@@ -11,7 +11,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 # import os
-# import sys
+import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
 
@@ -40,8 +40,19 @@ copybutton_prompt_is_regexp = True
 
 # https://github.com/wpilibsuite/sphinxext-opengraph
 ogp_site_url = "https://pycamp.pycon.jp/"
-ogp_image = "https://pycamp.pycon.jp/_static/python-boot-camp-logo.png"
-ogp_use_first_image = True
+
+# https://sphinxext-opengraph.readthedocs.io/en/latest/socialcards.html
+ogp_social_cards = {
+    "enable": True,
+    "image": "images/python-boot-camp-logo.png",
+    "font": "Noto Sans CJK JP",
+}
+
+# font settings for macOS and Windows
+if sys.platform == "darwin":
+    ogp_social_cards["font"] = "Hiragino Sans"
+elif sys.platform == "win32":
+    ogp_social_cards["font"] = "MS PGothic"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/source/conf.py
+++ b/source/conf.py
@@ -50,7 +50,7 @@ ogp_social_cards = {
 
 # font settings for macOS and Windows
 if sys.platform == "darwin":
-    ogp_social_cards["font"] = "Hiragino Sans"
+    ogp_social_cards["font"] = "Hiragino Maru Gothic Pro"
 elif sys.platform == "win32":
     ogp_social_cards["font"] = "MS PGothic"
 


### PR DESCRIPTION
チケットへのリンク

- https://pyconjp.atlassian.net/browse/ISSHA-3067

このレビューで確認して欲しい点

- [x] 手元でsocial cardsが生成される
- `build/html/_images/social_previews` の下に、以下のようなソーシャルカードがページごとに生成される
- https://www.pycon.jp/ はすでに設定済みです
 
![summary_textbook_2_intro_dfa22f3a](https://github.com/pyconjp/pycamp.pycon.jp/assets/988241/5594570b-c4c4-47b0-a6b3-a5cc529654c4)
