### PR TITLE
7.3events.pyおよび7.4funcs.pyの保存先を、scrapingフォルダ内と明記

### DIFF
--- a/source/textbook/7_scraping.md
+++ b/source/textbook/7_scraping.md
@@ -70,7 +70,7 @@ Web APIの例としてconnpassのAPIを実行して、pythonというキーワ�
 
 - [APIリファレンス - connpass](https://connpass.com/about/api/)
 
-下記のコードを `events.py` という名前で保存します({numref}`events-py`)。
+下記のコードを `events.py` という名前で、先ほど作成したscrapingフォルダ内に保存します({numref}`events-py`)。
 
 (events-py)=
 
@@ -153,7 +153,7 @@ Web APIの例としてconnpassのAPIを実行して、pythonというキーワ�
 組み込み関数一覧ページ
 ```
 
-下記コードを `funcs.py` という名前で保存します({numref}`funcs-py`)。
+下記コードを `funcs.py` という名前で、scrapingフォルダ内に保存します({numref}`funcs-py`)。
 
 (funcs-py)=
 


### PR DESCRIPTION
チケットへのリンク

- https://github.com/pyconjp/pycamp.pycon.jp/issues/148

このレビューで確認して欲しい点

- [ ] 7.3で作成したevents.pyおよび7.4で作成したfuncs.pyファイルの保存先がscrapingフォルダ内であることを明記
- [ ] Issuesでは7.4のファイル名がsimple.pyとなっていたが、funcs.pyに名称変更されていると思われるのでご確認お願いします。

contributorに追加を希望する場合は、以下にチェックを入れて`source/organize/3_contributers.rst`に自分の名前を入れた変更をこのPull Requestに加えること

- [ ] contributorに追加を希望する
