### PR TITLE
devcontainer設定追加、noto-cjk手順追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {},
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	"onCreateCommand": "bash .devcontainer/on_create_command.sh"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/on_create_command.sh
+++ b/.devcontainer/on_create_command.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+sudo apt update
+sudo apt install fonts-noto-cjk
+rm -rf ~/.cache/matplotlib
+
+pip install -U pip setuptools
+pip install -r requirements.txt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 * Read the Docs のプロジェクトページ: Read https://readthedocs.org/projects/bootcamp-text/
 * www.pycon.jp の説明ページ: https://www.pycon.jp/support/bootcamp.html
 
+## ビルド環境準備
+
+Ubuntu環境でのフォントインストール
+```
+$ sudo apt update
+$ sudo apt install fonts-noto-cjk
+$ rm -rf ~/.cache/matplotlib
+```
+
 ## How to build
 
 ```


### PR DESCRIPTION
- devcontainerでビルドしやすいように環境設定しました
- note-cjk インストール手順を追加しました
- 起動が高速でcjkフォントも入って便利