### PR TITLE
現状のファイル名に合わせて3_contributers.mdのpathを修正

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@
 - [ ] hogehoge
 - [ ] fugafuga
 
-contributorに追加を希望する場合は、以下にチェックを入れて`source/organize/3_contributers.rst`に自分の名前を入れた変更をこのPull Requestに加えること
+contributorに追加を希望する場合は、以下にチェックを入れて`source/organize/3_contributers.md`に自分の名前を入れた変更をこのPull Requestに加えること
 
 - [ ] contributorに追加を希望する

--- a/source/organize/3_contributers.md
+++ b/source/organize/3_contributers.md
@@ -28,3 +28,4 @@ Python Boot Campのテキスト作成には以下の人たちが関わってい�
 - [Takeshi_Izawa](https://github.com/zxb04116)
 - [onishi_feuer](https://github.com/crucis-onishi)
 - [soogie](https://github.com/soogie)
+- [Kaoki729](https://github.com/Kaoki729)


### PR DESCRIPTION
チケットへのリンク

- (JIRAまたはgithub issueへのリンク)
- https://github.com/pyconjp/pycamp.pycon.jp/issues/247

このレビューで確認して欲しい点

- [ ] 現状のファイル名に合わせて3_contributers.mdのpathを修正

contributorに追加を希望する場合は、以下にチェックを入れて`source/organize/3_contributers.md`に自分の名前を入れた変更をこのPull Requestに加えること

- [x] contributorに追加を希望する
